### PR TITLE
improve error logging

### DIFF
--- a/src/main/kotlin/chaperone/writer/LogWriter.kt
+++ b/src/main/kotlin/chaperone/writer/LogWriter.kt
@@ -60,7 +60,7 @@ class LogWriter(private val config: LogOutputConfig) : OutputWriter {
             OutputFormat.logstash -> {
                 LogstashEncoder().apply {
                     throwableConverter = ShortenedThrowableConverter().apply {
-                        maxDepthPerThrowable = 20
+                        maxDepthPerThrowable = 30
                         maxLength = 2048
                         shortenedClassNameLength = 100
                     }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
                             <fieldName>extendedStackTrace</fieldName>
                             <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
                                 <rootCauseFirst>true</rootCauseFirst>
-                                <maxLength>50</maxLength>
+                                <maxLength>500</maxLength>
                             </throwableConverter>
                         </stackTrace>
                     </providers>


### PR DESCRIPTION
fixes truncated log situations like this:
```
"extendedStackTrace":"java.lang.IllegalStateException: When a templa...\n"},
```