### PR TITLE
write output for each check

### DIFF
--- a/src/main/kotlin/chaperone/App.kt
+++ b/src/main/kotlin/chaperone/App.kt
@@ -45,16 +45,7 @@ class App : CliktCommand() {
                                 delay(check.millisToNextScheduledExecution())
                             }
 
-                            val results = check.execute()
-                            results.forEach { result ->
-                                outputWriters.forEach {
-                                    try {
-                                        it.write(result)
-                                    } catch (e: Exception) {
-                                        log.error(e) { "Exception writing result" }
-                                    }
-                                }
-                            }
+                            check.execute(outputWriters)
 
                             // for interval checks, delay after each execution
                             check.interval?.run {
@@ -66,7 +57,6 @@ class App : CliktCommand() {
             }
             job.join()
         }
-
     }
 
     private fun startApiServer(checks: List<Check>, port: Int) {
@@ -90,5 +80,3 @@ class App : CliktCommand() {
 }
 
 fun main(args: Array<String>) = App().main(args)
-
-

--- a/src/test/kotlin/chaperone/CheckTest.kt
+++ b/src/test/kotlin/chaperone/CheckTest.kt
@@ -1,5 +1,6 @@
 package chaperone
 
+import chaperone.writer.OutputWriter
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.longs.shouldBeInRange
@@ -226,4 +227,26 @@ class CheckTest {
         check.millisToNextScheduledExecution().shouldBeInRange((millisToNextMinute - 500)..(millisToNextMinute + 1000))
     }
 
+    @Test
+    fun `executeCheck should write to the outputWriters`() {
+        val check = Check(
+            fileDirectory = File("."),
+            name = "always succeeds",
+            description = "should always be ok",
+            command = "true",
+            interval = Duration.ofMinutes(1),
+            timeout = Duration.ofSeconds(30)
+        )
+
+        var hasOutputBeenWritten = false
+        val outputWriter = object : OutputWriter {
+            override fun write(checkResult: CheckResult) {
+                hasOutputBeenWritten = true
+            }
+        }
+
+        val results = check.execute(listOf(outputWriter))
+        results[0].status.shouldBe(CheckStatus.OK)
+        hasOutputBeenWritten.shouldBeTrue()
+    }
 }


### PR DESCRIPTION
this is important for large lists of templated checks that may take a while to run. it can seem like no progress is being made if it waits for the entire batch to finish before writing output. resolves #36